### PR TITLE
Remove /signup endpoint and verif flow #46

### DIFF
--- a/models.go
+++ b/models.go
@@ -27,13 +27,6 @@ type convention struct {
 	Stripe_Product_ID string
 }
 
-// signup is used to parse JSON response from the signup microservice
-type signup struct {
-	Email_Address string `json:"address"`
-	Success       bool   `json:"success"`
-	Note          string `json:"note"`
-}
-
 type user struct {
 	Email_Address      string
 	Creation_Date      time.Time


### PR DESCRIPTION
Go straight to `/register` (actually should be called `/donate`, but this is gold-plating work!) , skipping email verification step.